### PR TITLE
Gngraph Implementation 

### DIFF
--- a/creds/gngraph/gngraph_pgres_dbcreds.json.sample
+++ b/creds/gngraph/gngraph_pgres_dbcreds.json.sample
@@ -1,0 +1,6 @@
+{
+    "dbserver": "XXXXXX",
+    "dbport": "XXXX",
+    "dbuser": "XXXX",
+    "dbpasswd": "XXXXXX"
+}

--- a/gngraph/config/gngraph_config.py
+++ b/gngraph/config/gngraph_config.py
@@ -8,6 +8,7 @@ class GNGraphConfig:
         self.gndata_graph_config_folder = configpath
         self.gnnode_id_fpath = configpath+"/gnnode_id.pkl"
         self.gnedge_id_fpath = configpath+"/gnedge_id.pkl"
+        self.gnbizrule_id_fpath = configpath+"/gnbizrule_id.pkl"
         
 
     def save_nodeid_max(self, node_id_val):
@@ -32,4 +33,17 @@ class GNGraphConfig:
         if not os.path.exists(self.gnedge_id_fpath):
             return 500000
         with open(self.gnedge_id_fpath, 'rb') as fs:
+            return pickle.load(fs)
+
+        
+    def save_bizr_relid_max(self, bizrid_val):
+        ##data_file_name="gnedgeid.pkl"
+        with open(self.gnbizrule_id_fpath, 'wb') as fs:
+           pickle.dump(bizrid_val, fs)
+
+    def get_bizr_relid_max(self):
+        ###data_file_name="gnedgeid.pkl"
+        if not os.path.exists(self.gnbizrule_id_fpath):
+            return 900000
+        with open(self.gnbizrule_id_fpath, 'rb') as fs:
             return pickle.load(fs)

--- a/gngraph/gngraph_dbops/gngraph_pgresdbops_srch.py
+++ b/gngraph/gngraph_dbops/gngraph_pgresdbops_srch.py
@@ -65,7 +65,7 @@ class       GNGraphSrchPgresDBOps:
                            .option("password", self.__gdb_dbpasswd) \
                            .option("driver", "org.postgresql.Driver") \
                            .load()
-                retDF.show(2)
+                ###retDF.show(2)
                 dnodeDF = self.datanode_flatten_jsonfields(retDF, spk)
                 
                 retDF.createOrReplaceTempView(tbl_name)
@@ -87,8 +87,8 @@ class       GNGraphSrchPgresDBOps:
             metanode_tbl = self.__gdb_metadb_schema+"."+self.__gdb_metanodes_tbl            
             datadb_connstr = "jdbc:postgresql://"+self.__gdb_dbserver+":"+self.__gdb_dbport+"/"+self.__gdb_datadb
 
-            print('GNPgresSrchOps:    metadbconnstr '+metadb_connstr)
-            print('GNPgresSrchOps:    metanode_tbl '+metanode_tbl)
+            ##print('GNPgresSrchOps:    metadbconnstr '+metadb_connstr)
+            ##print('GNPgresSrchOps:    metanode_tbl '+metanode_tbl)
             
             try:   
                 self.__gnmetaNodeDF = spk.read \
@@ -99,7 +99,7 @@ class       GNGraphSrchPgresDBOps:
                                        .option("password", self.__gdb_dbpasswd) \
                                        .option("driver", "org.postgresql.Driver") \
                                        .load()
-                self.__gnmetaNodeDF.show(2)
+                ####self.__gnmetaNodeDF.show(2)
                 self.__gnmetaNodeDF.createOrReplaceTempView("gnmetanodes")
                 print('GNPgresSrchOps: mapped dataframe COMPLETED ');
             except Exception as error :
@@ -125,7 +125,7 @@ class       GNGraphSrchPgresDBOps:
                                     .option("password", self.__gdb_dbpasswd) \
                                     .option("driver", "org.postgresql.Driver") \
                                     .load()
-                metaEdgeDF.show(2)
+                ###metaEdgeDF.show(2)
                 # also flatten json objects
                 print('GNPgressSrchOps: metaedgeDF mapped ')
                 edge_schema = spk.read.json(metaEdgeDF.rdd.map(lambda row: row.gnedgeprop)).schema
@@ -161,7 +161,7 @@ class       GNGraphSrchPgresDBOps:
                                     .option("password", self.__gdb_dbpasswd) \
                                     .option("driver", "org.postgresql.Driver") \
                                     .load()
-                metaNodeDF.show(2)
+                ####metaNodeDF.show(2)
                 print('GNPgressSrchOps: metaNodeDF mapped ')
                 # also flatten json objects
 
@@ -188,7 +188,7 @@ class       GNGraphSrchPgresDBOps:
        sqlstr = "SELECT * FROM gnmetanodes where gnnodename='"+node+"'"
        print('GNPgresSrchOps: get_metanode_info:  sqlstr '+sqlstr)
        nodeEnt = spk.sql(sqlstr)
-       nodeEnt.show()
+       ###nodeEnt.show()
        jobj = json.loads(nodeEnt.toJSON().first())
        return jobj
 
@@ -206,7 +206,7 @@ class       GNGraphSrchPgresDBOps:
         
 
         print('GNPgresDBSrchOps: Flatten dataframe for JSON Objects')
-        datanodeFlattenDF.show(2)
+        ###datanodeFlattenDF.show(2)
         #n1DF = baseDataNodeDF.withColumn("gndatanodeobj", from_json("gndatanodeobj", n1_schema))\
         #                     .select(col('gnnodeid'), col('gnnodetype'), col('gnmetanodeid'), col('uptmstmp'), col('gndatanodeobj.*'))
         # Flatten gndatanodeprop
@@ -232,7 +232,7 @@ class       GNGraphSrchPgresDBOps:
         
         retDF = None
         if dnodeDF is not None:
-           dnodeDF.show(1)
+           ###dnodeDF.show(1)
            # flatten gndatanodeprop and gndatanodeobj (actual dataset attibutes)
            retDF = self.datanode_flatten_jsonfields(dnodeDF, spk)
            # also map the node to tempview with nodename
@@ -241,3 +241,15 @@ class       GNGraphSrchPgresDBOps:
         return retDF
 
     
+    def  get_bizrule_metainfo(self, bizrid, spk):
+
+       if spk is None:
+          print('GNPgresSrchOps: spark is none ')
+
+       sqlstr = "SELECT * FROM gnbizrules where gnrelid='"+bizrid+"'"
+       print('GNPgresSrchOps: get_bizrule_metainfo:  sqlstr '+sqlstr)
+       bizrEnt = spk.sql(sqlstr)
+       #bizrEnt.show()
+       jobj = json.loads(bizrEnt.toJSON().first())
+       return jobj
+

--- a/gngraph/gngraph_dbops/gngraph_staticfileops.py
+++ b/gngraph/gngraph_dbops/gngraph_staticfileops.py
@@ -23,8 +23,8 @@ class  GNGraphStaticFileOps:
             self.gnedge_table = "gnedges"
             self.gnmetanode_filepath = self.gndata_graph_data_folder+"/"+"gnmetanodes.json"
             self.gnmetaedge_filepath = self.gndata_graph_data_folder+"/"+"gnmetaedges.json"
-
-
+            self.gnmetabizrules_filepath = self.gndata_graph_data_folder+"/"+"gnmetabizrules.json"  
+           
     def  metadb_nodes_append_write(self, metaDF):
 
 
@@ -79,17 +79,25 @@ class  GNGraphStaticFileOps:
             json.dump(jdict, fp)
 
             
-    def  get_metnode_id(self, name):
+    def  metadb_metanode_id_get(self, name):
 
           metaDF = pds.read_json(self.gnmetanode_filepath)
-          rDF = metaDF.query('gnnodename == "sales"')
-          nres = rDF["gnnodeid"].count()
-          if (nres > 0):
-              gnnode_id = rDF["gnnodeid"][0]
+          metaDF.head(2)
+          print('gngrpStaticFileOps: getting metanode: '+self.gnmetanode_filepath)
+          
+          rDF = metaDF.query('gnnodename == "'+name+'"')
+          ##nres = rDF["gnnodeid"].count()
+          ##if (nres > 0):
+
+          print('gngrpStaticFileOps: Getting metanode id '+name)
+          if (rDF.shape[0] > 0):
+              for x in rDF["gnnodeid"]:
+                  gnnode_id = x
           else:
               gnnode_id = -1
           return gnnode_id
 
+      
     def   create_gndata_datadirs(self, bizdomain, nodename):
 
          bizdomain_dir = self.gndata_graph_data_folder+"/"+bizdomain
@@ -127,3 +135,52 @@ class  GNGraphStaticFileOps:
         with open(self.gnmetaedge_filepath, 'w') as fp:
             json.dump(jdict, fp)
 
+
+    def  metadb_bizrules_rule_chk(self, srcnodeid, rulename):
+
+        relid = -1
+        if path.exists(self.gnmetabizrules_filepath):
+        
+           metaBizRDF = pds.read_json(self.gnmetabizrules_filepath)
+           rDF = metaBizRDF.query("gnsrcnodeid == "+str(srcnodeid)+' and  gnrelname == "'+rulename+'" ')
+           relid = -1
+           ###nres = rDF["gnnodeid"].count()
+           if (rDF.shape[0] > 0):
+              for x in rDF["gnrelid"]:
+                  ##print(' parsing x '+str(x))
+                  ##relid = rDF["gnnodeid"][0]
+                  relid = x
+           else:
+               relid = -1
+
+        return relid
+
+
+    def      metadb_bizrules_bizr_get(self, bizrid):
+
+        rJson = {}
+        if path.exists(self.gnmetabizrules_filepath):
+           metaBizRDF = pds.read_json(self.gnmetabizrules_filepath)
+           rDF = metaBizRDF.query("gnrelid == "+str(bizrid)+" ")
+           res = resDF.to_json(orient="records")
+           rJson = json.loads(res)
+
+        return rJson
+
+
+    
+            
+    def  metadb_bizrules_append_write(self, metaDF):
+
+
+        if path.exists(self.gnmetabizrules_filepath):
+            cDF = pds.read_json(self.gnmetabizrules_filepath)
+            jDF = cDF.append(metaDF, ignore_index=True)
+        else:
+            jDF = metaDF
+
+        jstr = jDF.to_json(orient='records')
+        jdict = jDF.to_dict(orient='records')
+
+        with open(self.gnmetabizrules_filepath, 'w') as fp:
+            json.dump(jdict, fp)

--- a/gngraph/gngraph_dbops/gngraph_staticfileops_srch.py
+++ b/gngraph/gngraph_dbops/gngraph_staticfileops_srch.py
@@ -41,7 +41,7 @@ class  GNGraphSrchStaticFileOps:
        sqlstr = "SELECT * FROM gnmetanodes where gnnodename='"+node+"'"
        print('get_metanode_info:  sqlstr '+sqlstr)
        nodeEnt = spk.sql(sqlstr)
-       nodeEnt.show()
+       ##nodeEnt.show()
        jobj = json.loads(nodeEnt.toJSON().first())       
        return jobj
                        
@@ -69,7 +69,7 @@ class  GNGraphSrchStaticFileOps:
         
         if path.exists(dnode_fpath):
            retDF = spk.read.json(dnode_fpath)
-           retDF.show(1)
+           ##retDF.show(1)
            # flatten gndatanodeprop and gndatanodeobj (actual dataset attibutes)
            dnodeDF = self.datanode_flatten_jsonfields(retDF, spk)
            # also map the node to tempview with nodename
@@ -87,7 +87,7 @@ class  GNGraphSrchStaticFileOps:
         retDF = None
         if path.exists(edge_fpath):
            metaEdgeDF = spk.read.json(edge_fpath)
-           metaEdgeDF.show(1)
+           ####metaEdgeDF.show(1)
            # flatten gnedgeprop  (actual dataset attibutes)
            edge_schema = spk.read.json(metaEdgeDF.rdd.map(lambda row: row.gnedgeprop)).schema
            self.__gnmetaEdgeDF = metaEdgeDF.withColumn("gnedgeprop", from_json("gnedgeprop", edge_schema)).select(col('gnedgeid'), col('gnedgename'), col('gnedgetype'), col('gnsrcnodeid'), col('gntgtnodeid'),  col('gnedgeprop.*'))
@@ -107,7 +107,7 @@ class  GNGraphSrchStaticFileOps:
         retDF = None
         if path.exists(mnodes_fpath):
            metaNodeDF = spk.read.json(mnodes_fpath)
-           metaNodeDF.show(1)
+           ##metaNodeDF.show(1)
            # flatten gnedgeprop  (actual dataset attibutes)
            mnode_schema = spk.read.json(metaNodeDF.rdd.map(lambda row: row.gnnodeprop)).schema
            self.__gnmetaNodeDF = metaNodeDF.withColumn("gnnodeprop", from_json("gnnodeprop", mnode_schema)).select(col('gnnodeid'), col('gnnodename'), col('gnnodetype'), col('gnnodeprop.*'))
@@ -116,5 +116,16 @@ class  GNGraphSrchStaticFileOps:
            self.__gnmetaNodeDF.createOrReplaceTempView("gnmetanodes")
         return self.__gnmetaNodeDF
 
+    def  get_bizrule_metainfo(self, bizrid, spk):
+
+       if spk is None:
+          print('GNPgresSrchOps: spark is none ')
+
+       sqlstr = "SELECT * FROM gnbizrules where gnrelid='"+bizrid+"'"
+       print('GNPgresSrchOps: get_bizrule_metainfo:  sqlstr '+sqlstr)
+       bizrEnt = spk.sql(sqlstr)
+       #bizrEnt.show()
+       jobj = json.loads(bizrEnt.toJSON().first())
+       return jobj
 
 

--- a/gngraph/ingest/bizrules/gngraph_bizrules_datarepo.py
+++ b/gngraph/ingest/bizrules/gngraph_bizrules_datarepo.py
@@ -1,0 +1,346 @@
+####################################################################
+# GNGraph DB module does following tasks
+#    - Add data relationships
+#    - Add relationship attributes to node to neo4j
+###################################################################
+import os
+import csv
+import json
+import sys
+import pandas as pds
+import numpy as np
+import warnings
+
+from moz_sql_parser import parse
+from pyspark.sql import SparkSession
+from pyspark.sql import functions as F
+from pyspark.sql.functions import lit,split
+from pyspark.sql import Row
+from pyspark.sql.types import *
+
+
+
+import re
+warnings.simplefilter('ignore')
+curentDir = os.getcwd()
+parentDir = curentDir.rsplit('/', 1)[0]
+gngraph_rootDir = parentDir.rsplit('/', 1)[0]
+
+
+
+if parentDir not in sys.path:
+    sys.path.append(parentDir)
+if gngraph_rootDir not in sys.path:
+    sys.path.append(gngraph_rootDir)
+
+    
+from config.gngraph_config import GNGraphConfig
+from gngraph_dbops.gngraph_pgresdbops import GNGraphPgresDBOps
+from gngraph_dbops.gngraph_staticfileops import GNGraphStaticFileOps
+from ingest.bizrules.gngraph_bizrules_ops import GNGraphBizRuleOps
+from search.gngraph_sqlparser import GNGraphSqlParserOps
+from search.gngraph_search_main import gngrp_srch_qry_api
+
+class      GNGraphBizRulesDataRepoOps:    
+
+    def     __init__(self, fileargs, gdbargs, bizrid, spk):
+        self.__fargs = fileargs;
+        self.__gdbargs = gdbargs
+
+        if (self.__gdbargs["gdbflag"]):
+           self.gdb_conn_setup()
+
+        if (self.__gdbargs["staticfiles"]):
+           gngraph_folder = self.__gdbargs["gndatafolder"]+"/gngraph";
+           self.__gngrp_sfops = GNGraphStaticFileOps(gngraph_folder)
+
+        ## get config class
+        if (self.__gdbargs["gndatafolder"]):
+            id_cfg_path = self.__gdbargs["gndatafolder"]+"/gngraph/config"
+            self.__gngrp_cfg = GNGraphConfig(id_cfg_path)
+
+        ###set metanode columns for pgresdb and static files
+        self.__metanode_columns=["gnnodeid", "gnnodename", "gnnodetype", "gnnodeprop", "uptmstmp"]
+        self.__metaedge_columns=["gnedgeid", "gnedgename", "gnedgetype", "gnsrcnodeid", "gntgtnodeid", "gnedgeprop", "uptmstmp"]
+        self.__metabizr_columns=["gnrelid", "gnrelname", "gnreltype", "gnsrcnodeid", "gntgtnodeid", "gnmatchnodeid", "gnrelprop", "gnrelobj", "state", "freq", "uptmstmp"]
+
+        self.__spk = spk
+        accessmode="pgres"
+        
+        self.__gn_bizr_metaops = GNGraphBizRuleOps( self.__fargs, gdbargs, accessmode)
+        jstr = self.__gn_bizr_metaops.bizr_get_by_id(bizrid)
+
+        #self.__gn_rel_json = json.loads(jstr)
+        self.__gn_bizr_id = bizrid
+        self.__gn_rel_json = jstr[0]
+        print('BizrDatarepo: meta bizrinfo ')
+        print(self.__gn_rel_json)
+        
+        gsql_p = self.__gn_rel_json["gnrelobj"]
+        self.__gn_rel_msql = str(gsql_p["matchcondition"])
+        self.__gn_rel_srcnode = str(gsql_p["srcnode"])
+        self.__gn_rel_targetnode = str(gsql_p["targetnode"])
+        self.__gn_rel_bizrname = str(gsql_p["rulename"])
+        
+        self.__gn_rsql_parsed = GNGraphSqlParserOps(self.__gn_rel_msql)
+        
+        entlist = self.__gn_rsql_parsed.get_entlist()
+        reformatted_sql = self.__gn_rsql_parsed.gn_sqlp_reformat_qry()
+
+        print('BizDataRepos: reformated sql '+reformatted_sql)
+
+    def    gdb_conn_setup(self):
+        
+        with open(self.__gdbargs["gdbcredsfpath"], encoding="utf-8") as fh:
+             gdb_creds = json.load(fh)
+
+        self.__gdbMetaDBConnp = GNGraphPgresDBOps.from_args(gdb_creds["dbserver"], gdb_creds["dbport"], gdb_creds["dbuser"], gdb_creds["dbpasswd"], self.__gdbargs["gnmetaDB"], "gnmetadb")
+        self.__gdbDataDBConnp = GNGraphPgresDBOps.from_args(gdb_creds["dbserver"], gdb_creds["dbport"], gdb_creds["dbuser"], gdb_creds["dbpasswd"],  self.__gdbargs["gndataDB"], "gndatadb")
+
+    def    get_rel_json(self):
+        return self.__gn_rel_json
+    def    get_rel_srcnode(self):
+        return self.__gn_rel_srcnode
+    def    get_rel_targetnode(self):
+        return self.__gn_rel_targetnode
+    
+    def    get_rsql_entlist(self):
+        return self.__gn_rsql_parsed.get_entlist()
+    def    get_rsql_entlist_alias(self):
+        return self.__gn_rsql_parsed.get_entlist_alias()
+    def    get_rsql_from_str(self):
+        return self.__gn_rsql_parsed.get_from_str()
+    def    get_rsql_where_str(self):
+        return self.__gn_rsql_parsed.get_where_str()
+    
+    def    bizrule_rule_get(self, bizrid):
+
+        if (self.__gncfg["gdbflag"] == 1):
+            metabizr_obj = self.__gngrp_dbops.get_bizrule_metainfo(bizrid, self.__spk)
+        elif (self.__gncfg["staticfiles"] == 1):
+            metabizr_obj = self.__gngrp_sfops.get_bizrule_metainfo(bizrid, self.__spk)
+        return metabizr_obj
+
+
+    def     bizrule_rule_execute(self, bizrid):
+                  
+       print( 'bizrules_rule_execute: Starting for biz relid'+ str(bizrid) +' ')
+       metabizr_obj = self.bizrule_rule_get(bizrid)
+       print('GnGrpBizRuleDataRepoExecute: parsing matching cond '+metabizr_obj["gnrelobj"])
+
+       gnsqlp = GNGraphSqlParserOps(metabizr_obj["gnrelobj"]) 
+
+
+
+       
+
+    def      bizr_datanodes_setup_api(self):
+
+        ###entlist is list of nodesname that need to be mapped
+        for ent in self.__entlist:
+            entD = {}
+            ent_metanode_info =  self.get_metanode_info(ent)
+            jprop = json.loads(ent_metanode_info["gnnodeprop"])
+            node_name = ent_metanode_info["gnnodename"]
+            bizdomain = jprop["bizdomain"]
+
+            print("GNGrpSrchMain:  setup api nodename "+node_name+" bizdomain:"+bizdomain)
+            entnodeDF = self.get_datanode_mapped_df(node_name, bizdomain)
+            if (entnodeDF is not None):
+               ent_metanode_info["df"] = entnodeDF
+               self.__gngrp_dnDFList.append(ent_metanode_info)
+            else:
+               print("gngrp_srch_setup: "+node_name+" nodeDF is empty ")
+
+        return
+
+
+    def   create_bizrnode_edges(self, dnjson):
+
+         #gn_node_parent_id = self.get_metanode_parent_id()
+         #gn_nodeid_max_c = self.__gngrp_cfg.get_nodeid_max()
+         gn_edgeid_max_c = self.__gngrp_cfg.get_edgeid_max()
+         gn_edgeid_c = gn_edgeid_max_c + 1
+         
+         ###self.__bizrDNodeDF = pds.DataFrame.from_dict(dnjson, orient="index")
+         self.__bizrDNodeDF = pds.read_json(dnjson)
+         self.__nodeEdgeDF = self.__bizrDNodeDF.copy()
+         ####self.__nodeEdgeDF.rename( columns=({'gnnodeid':'gntgtnodeid', 'gnmetanodeid':'gnsrcnodeid'}), inplace=True)
+
+         ## Add gnedgeid
+         self.__nodeEdgeDF['gnedgeid'] = pds.RangeIndex(stop=self.__nodeEdgeDF.shape[0])+gn_edgeid_c
+
+         #### Add gnedgename IS
+         ##relname="IS"
+         self.__nodeEdgeDF["gnedgename"] = self.__gn_rel_bizrname
+
+         ### Add gnedgetype
+         edgetype="GNBizRuleNodeEdge"
+         self.__nodeEdgeDF["gnedgetype"] = edgetype
+
+         #### Add gnedgeprop
+         self.__nodeEdgeDF["gnedgeprop"] = self.__nodeEdgeDF["gntgtnodeid"].apply(lambda x: json.dumps({'gnbizrelid':str(self.__gn_bizr_id) }))
+
+          #### Add gnedgeprop
+          #####  self.__nodeEdgeDF["gnedgeprop"] = self.__nodeEdgeDF["gntgtnodeid"].apply(lambda x: json.dumps({'gntgtlabel':self.gnnode_parent_name+str(x), 'gnsrclabel':self.gnnode_parent_name,  "gnsrcdomain": "gnmeta", "gntgtnodeloc":   self.__fargs["nodename"], "gntgtdomain": self.__fargs["bizdomain"] }))
+
+         
+         #### Update utimestamp
+         utmstmp = pds.Timestamp.now()
+         self.__nodeEdgeDF['uptmstmp'] = utmstmp
+
+         #####Select edgenode columns and prepare for write
+         self.__gndatanodeEdgeDF = self.__nodeEdgeDF[["gnedgeid","gnedgename","gnedgetype","gnsrcnodeid","gntgtnodeid","gnedgeprop", "uptmstmp"]]
+
+         print('GNGrpBizRuleOps: showing biznodes ')
+         #self.__gndatanodeEdgeDF.columns
+
+         ## write edges to database
+         if (self.__gdbargs["gdbflag"]):
+            self.__gdbMetaDBConnp.metadb_edges_write(self.__gndatanodeEdgeDF)
+         if (self.__gdbargs["staticfiles"]):
+             self.__gndatanodeEdgeDF["uptmstmp"] = self.__gndatanodeEdgeDF["uptmstmp"].astype(str)
+             self.__gngrp_sfops.metadb_edges_append_write(self.__gndatanodeEdgeDF)
+
+         #save edgeid max
+         gn_edgeid_max_n = self.__gndatanodeEdgeDF.shape[0]+gn_edgeid_c-1
+         self.__gngrp_cfg.save_edgeid_max(gn_edgeid_max_n)
+
+        
+####################################
+    
+
+               
+def        gngrp_bizr_rule_execute_api(bizrid, spark, gndata_folder, gngraph_creds_folder):
+
+        gdb_creds_filepath=gngraph_creds_folder+"/gngraph_pgres_dbcreds.json"
+        fileargs = {}
+        gdbargs = {}
+        gdbargs["gdb"] = "pgres"
+        gdbargs["gdbflag"] = 1
+        gdbargs["gdbcredsfpath"] = gdb_creds_filepath
+        gdbargs["gnmetaDB"] = "gngraph_db"
+        gdbargs["gndataDB"] = "gngraph_db"
+        gdbargs["staticfiles"] = 1
+        gdbargs["staticfpath"] = gndata_folder+"/uploads";
+        gdbargs["gndatafolder"] = gndata_folder
+
+        fargs = {}
+        fargs["gngraphfolder"] = gndata_folder+"/gngraph"
+        fargs["gnmetanodesfname"] = "gnmeanodes.json"
+        fargs["gnmetaedgesfname"] = "gnmetaedges.json"
+
+        accessmode="files"
+        
+        ##entlist = gngrph_srch_get_entlist(sqlst)
+        gngrp_bizr_ops = GNGraphBizRulesDataRepoOps(fargs, gdbargs, bizrid, spark)
+       
+        ##gnsrch_ops = GNgraphSearchOps(gndata_folder, accessmode, fargs, gdbargs, gngrp_bizr_ops.__entlist, spark)
+        ##gnsrch_ops.gngraph_search_setup_api()
+        gndata_folder="/home/jovyan/GnanaDiscover/GnanaPath/gndata"
+        gngraph_creds_folder = "/home/jovyan/GnanaDiscover/GnanaPath/creds/gngraph"
+
+        ### Set spark session
+        spark = SparkSession.builder.appName(app_name).getOrCreate()
+        rel_json = gngrp_bizr_ops.get_rel_json()
+        srcnode = gngrp_bizr_ops.get_rel_srcnode()
+        targetnode = gngrp_bizr_ops.get_rel_targetnode()
+        print('BizrDataRepo: rel json ')
+        print(rel_json)
+        print(srcnode)
+        print(targetnode)
+
+        
+        rjson_sql = ""
+        ### Prepare sql statement to get gnsrcnodeid, gntgtnodeid so that new edge relation can be created
+        ent_list = gngrp_bizr_ops.get_rsql_entlist()
+        ent_alias_list = gngrp_bizr_ops.get_rsql_entlist_alias()
+        frm_str = gngrp_bizr_ops.get_rsql_from_str()
+        where_str = gngrp_bizr_ops.get_rsql_where_str()
+        
+        print('BizrDataRepo: RSQL is parsed ')
+        print('****************************')
+        print('Ent list')
+        print(ent_list)
+        print('Ent Alias List')
+        print(ent_alias_list)
+        print('From str ')
+        print(frm_str)
+        print('where str ')
+        print(where_str)
+
+    
+        
+        tent_list = ""
+        i=0
+        for e in ent_list:
+            if (e == srcnode):
+                src_idx = i
+            if (e == targetnode):
+                tgt_idx = i
+
+            i = i+1
+
+        if (ent_alias_list[src_idx] is None):
+            tent_list += ent_list[src_idx]+"."+"gnnodeid as gnsrcnodeideid "
+        else:
+            tent_list += ent_alias_list[src_idx]+"."+"gnnodeid as gnsrcnodeid "
+
+        tent_list += ", " 
+            
+        if (ent_alias_list[tgt_idx] is None):
+            tent_list += ent_list[tgt_idx]+"."+"gnnodeid as gntgtnodeideid "
+        else:
+            tent_list += ent_alias_list[tgt_idx]+"."+"gnnodeid as gntgtnodeid"
+
+        rjson_sql += "Select "+tent_list+" "
+        rjson_sql += frm_str+ " "
+        rjson_sql += where_str+ " "
+        print('***********************************')
+        print('BizrDataRepo: processed rSQL')
+        print(rjson_sql)
+        nodesonly = 1    
+        (nJSON, eJSON) = gngrp_srch_qry_api(rjson_sql, spark, gndata_folder, gngraph_creds_folder, nodesonly)
+
+        nfile="bnodes.json"
+        with open(nfile, 'w') as fp:
+            json.dump(nJSON, fp)
+
+        nJSONStr = json.dumps(nJSON)    
+        ### Add Edges to bizrules
+        gngrp_bizr_ops.create_bizrnode_edges(nJSONStr)
+
+        ## We need to create edges between src node and target node
+        return (nJSON, eJSON)
+        
+       
+
+if __name__ == '__main__':
+
+    print("Starting gn ingest file")
+    curDir = os.getcwd()
+    rtDir = curDir.rsplit('/', 1)[0]
+    app_name="gngraph"
+
+    if rtDir not in sys.path:
+        sys.path.append(rtDir)
+
+    gndata_folder="/home/jovyan/GnanaDiscover/GnanaPath/gndata"
+    gngraph_creds_folder = "/home/jovyan/GnanaDiscover/GnanaPath/creds/gngraph"
+    
+    bizrid = 900001    
+    ### Set spark session
+    spark = SparkSession.builder.appName(app_name).getOrCreate()
+
+    (nJSON, eJSON) = gngrp_bizr_rule_execute_api(bizrid, spark, gndata_folder, gngraph_creds_folder)
+    rfile="bizr_nodes.json"
+    with open(rfile, 'w') as fp:
+            json.dump(nJSON, fp)
+
+
+    efile="bizr_edges.json"
+    with open(efile, "w") as fp:
+            json.dump(eJSON, fp)
+
+
+

--- a/gngraph/ingest/bizrules/gngraph_bizrules_ops.py
+++ b/gngraph/ingest/bizrules/gngraph_bizrules_ops.py
@@ -1,0 +1,254 @@
+####################################################################
+# GnanaWarehouse_DB module does following tasks
+#    - Add meta relationships
+#    - Add meta attributes to node to neo4j
+###################################################################
+
+import os
+import csv
+import json
+import sys
+import numpy as np
+import warnings
+import pandas as pds
+
+import os,sys
+curentDir = os.getcwd()
+parentDir = curentDir.rsplit('/', 1)[0]
+gngraph_rootDir = parentDir.rsplit('/', 1)[0]
+
+
+if parentDir not in sys.path:
+    sys.path.append(parentDir)
+if gngraph_rootDir not in sys.path:
+    sys.path.append(gngraph_rootDir)
+
+from config.gngraph_config import GNGraphConfig
+from gngraph_dbops.gngraph_pgresdbops import GNGraphPgresDBOps
+from gngraph_dbops.gngraph_staticfileops import GNGraphStaticFileOps
+
+
+import re
+warnings.simplefilter('ignore')
+
+"""
+Biz rules meta repo Pandas-based
+
+"""
+
+class     GNGraphBizRuleOps:
+
+    def     __init__(self, fileargs, gdbargs, accessmode):
+        self.__fargs = fileargs;
+        self.__gdbargs = gdbargs
+        self.__gncfg = {}
+
+
+        if (accessmode == "files"):
+          self.__gncfg["staticfiles"] = 1
+          self.__gncfg["gdbflag"] = 0
+        else:
+          self.__gncfg["staticfiles"] = 0
+          self.__gncfg["gdbflag"] = 1
+
+          
+        if (self.__gdbargs["gdbflag"]):
+            self.gdb_conn_setup()
+
+
+        if (self.__gdbargs["staticfiles"]):
+           gngraph_folder = self.__gdbargs["gndatafolder"]+"/gngraph";
+           self.__gngrp_sfops = GNGraphStaticFileOps(gngraph_folder)
+
+           
+        ## get config class
+        if (self.__gdbargs["gndatafolder"]):
+            id_cfg_path = self.__gdbargs["gndatafolder"]+"/gngraph/config"
+            self.__gngrp_cfg = GNGraphConfig(id_cfg_path)
+
+        ###set metanode columns for pgresdb and static files
+        self.__metanode_columns=["gnnodeid", "gnnodename", "gnnodetype", "gnnodeprop", "uptmstmp"]
+        self.__metaedge_columns=["gnedgeid", "gnedgename", "gnedgetype", "gnsrcnodeid", "gntgtnodeid", "gnedgeprop", "uptmstmp"]
+        self.__metabizr_columns=["gnrelid", "gnrelname", "gnreltype", "gnsrcnodeid", "gntgtnodeid", "gnmatchnodeid", "gnrelprop", "gnrelobj", "state", "freq", "uptmstmp"]
+    
+
+        
+    def    gdb_conn_setup(self):
+
+        with open(self.__gdbargs["gdbcredsfpath"], encoding="utf-8") as fh:
+             gdb_creds = json.load(fh)
+
+        self.__gdbMetaDBConnp = GNGraphPgresDBOps.from_args(gdb_creds["dbserver"], gdb_creds["dbport"], gdb_creds["dbuser"], gdb_creds["dbpasswd"], self.__gdbargs["gnmetaDB"], "gnmetadb")
+
+        self.__gdbDataDBConnp = GNGraphPgresDBOps.from_args(gdb_creds["dbserver"], gdb_creds["dbport"], gdb_creds["dbuser"], gdb_creds["dbpasswd"],  self.__gdbargs["gndataDB"], "gndatadb")
+
+
+        
+           
+    def      bizrules_metarepo_metanode_chk(self, nodename):
+        nodeid = None
+        if (self.__gdbargs["gdbflag"]):
+            nodeid = self.__gdbMetaDBConnp.metadb_metanode_chk_nodeid(nodename)
+            
+        if (self.__gdbargs["staticfiles"]):
+            nodeid = self.__gngrp_sfops.metadb_metanode_id_get(nodename)
+        return nodeid
+        
+    def      bizrule_verify_rules(self, rjson):
+
+      fail = 0
+      # Verify if srcnode exists in metarepo
+      print("gngrp_bizrules_verify: verify rules")
+      if (rjson["srcnode"]):
+        if (verbose > 2):
+            print('gngrp_bizrules_rule_verify: verify if srcnode exists:' + rjson['srcnode'])
+        l = self.gngrp_metarepo_metanode_check(rjson['srcnode'])
+        if (l == 0):
+            fail = fail + 1
+      else:
+        fail = fail + 1
+
+      if (rjson["targetnode"]):
+        if (verbose > 2):
+            print(
+                'gndw_rwl_verify_rules: verify if tgtnode exists:' +
+                rjson['targetnode'])
+        l = self.gndw_metarepo_metanode_check(rjson['targetnode'])
+
+        if (l == 0):
+            fail = fail + 1
+      else:
+        fail = fail + 1
+
+      if (rjson["matchnode"]):
+
+        print('gngraph_rel_verify_rules: verify if matchnode exists:' +
+                rjson['matchnode'])
+        l = self.gndw_metarepo_metanode_check(rjson['matchnode'])
+        if (l == 0):
+            fail = fail + 1
+      else:
+        fail = fail + 1
+
+      return fail
+
+    
+
+    def     bizrules_rule_metarepo_add(self, rjson):
+        #srcnodeid = self.bizrules_metarepo_metanode_chk(rjson["srcnode"])
+        #tgtnodeid = self.bizrules_metarepo_metanode_chk( rjson["targetnode"])
+        #matchnodeid = self.bizrules_metarepo_metanode_chk( rjson["matchnode"])
+        (found, srcnodeid, tgtnodeid, matchnodeid) = self.bizrule_rel_rule_exists(rjson)
+        if (found != -1):
+            return -1
+        
+        gn_bizrule_rel_id = self.__gngrp_cfg.get_bizr_relid_max()+1
+        
+        rulename = rjson['rulename']
+
+        reltype="GNBizRule"
+        freq="daily"
+        state="Active"
+        up_tmstmp = pds.Timestamp.now()
+        bizrelprop = {"bizrulelabel": rjson["rulename"]}
+        bizrelprop_str = json.dumps(bizrelprop)
+        bizrel_json_str = json.dumps(rjson)
+        
+        bizrule_node_e = [gn_bizrule_rel_id, rjson["rulename"], reltype, srcnodeid, tgtnodeid, matchnodeid, bizrelprop_str, bizrel_json_str, state, freq, up_tmstmp]
+        self.__metaBizRuleDF = pds.DataFrame([bizrule_node_e], columns=self.__metabizr_columns)                     
+        print("gngrph_bizrule_add: Adding BizRule Node")
+
+        ###rfound = gndw_rel_rules_bizrule_relation_exists(rulename)
+
+        if (self.__gdbargs["gdbflag"]):
+           self.__gdbMetaDBConnp.metadb_bizrules_write(self.__metaBizRuleDF)
+
+        if (self.__gdbargs["staticfiles"]):
+            print("gngrp_bizrules_add: write rules to static files ")
+            self.__metaBizRuleDF["uptmstmp"] = self.__metaBizRuleDF["uptmstmp"].astype(str)
+            self.__gngrp_sfops.metadb_bizrules_append_write(self.__metaBizRuleDF)
+        self.__gngrp_cfg.save_bizr_relid_max(gn_bizrule_rel_id)
+  
+
+                
+    def     bizrule_rel_rule_exists(self, rjson):
+          # Check if Biz Rule Rulename exists
+          srcnode = rjson["srcnode"]
+          tgtnode = rjson["targetnode"]
+          matchnode = rjson["matchnode"]
+          rulename = rjson["rulename"]
+
+          srcnodeid = self.bizrules_metarepo_metanode_chk(rjson["srcnode"])
+          tgtnodeid = self.bizrules_metarepo_metanode_chk( rjson["targetnode"])
+          matchnodeid = self.bizrules_metarepo_metanode_chk( rjson["matchnode"])
+
+          if (srcnodeid is None):
+              return (-1, None, None, None)
+          
+          if (matchnodeid is None):
+              return (-1, None, None, None)
+          
+          relid = -1
+
+          if (self.__gdbargs["gdbflag"]):
+             relid = self.__gdbMetaDBConnp.metadb_bizrules_rule_chk(srcnodeid, rulename)            
+
+          if (self.__gdbargs["staticfiles"]):
+             relid = self.__gngrp_sfops.metadb_bizrules_rule_chk(srcnodeid, rulename)
+
+          return (relid, srcnodeid, tgtnodeid, matchnodeid)
+
+    def  bizr_get_by_id(self, bizrid):
+          if (self.__gncfg["staticfiles"] == 1):
+              bizr_json = self.__gngrp_sfops.metadb_bizrules_bizr_get(bizrid)
+
+          if (self.__gncfg["gdbflag"] == 1):
+              bizr_json = self.__gdbMetaDBConnp.metadb_bizrules_bizr_get(bizrid)
+          return bizr_json
+
+      
+# API to add business rules to graphdb
+def    gngraph_bizrules_rule_add_api(rjson, gndata_folder, gngraph_creds_folder):
+
+        print('gngrp_bizrules_add: adding bizrules to meta and data repo')
+
+        gdb_creds_filepath=gngraph_creds_folder+"/gngraph_pgres_dbcreds.json"
+
+        gdbargs = {}
+        gdbargs["gdb"] = "pgres"
+        gdbargs["gdbflag"] = 1
+        gdbargs["gdbcredsfpath"] = gdb_creds_filepath
+        gdbargs["gnmetaDB"] = "gngraph_db"
+        gdbargs["gndataDB"] = "gngraph_db"
+        gdbargs["staticfiles"] = 1
+        gdbargs["staticfpath"] = gndata_folder+"/uploads";
+        gdbargs["gndatafolder"] = gndata_folder
+
+        
+        fargs = {}
+        fargs["gngraphfolder"] = gndata_folder+"/gngraph"
+        fargs["gnmetanodesfname"] = "gnmeanodes.json"
+        fargs["gnmetaedgesfname"] = "gnmetaedges.json"
+
+        accessmode="pgres"
+
+        gnbizr_ops = GNGraphBizRuleOps(fargs, gdbargs, accessmode)
+
+        ret = gnbizr_ops.bizrules_rule_metarepo_add(rjson)
+        ###ret = gnbizr_ops.bizrules_rule_datarepo_add(rjson)
+        
+        return ret
+
+
+if __name__ == '__main__':
+
+    rfilepath = "./rel_ex.json"
+    gndata_folder="/home/jovyan/GnanaDiscover/GnanaPath/gndata"
+    gngraph_creds_folder = "/home/jovyan/GnanaDiscover/GnanaPath/creds/gngraph"
+
+    with open(rfilepath) as rfile:
+        rjson = json.load(rfile)
+        # matchcondition: "(salesorder.customerid \= customer.customerid) AND
+        # (salesorder.productid = product.productid)" }'
+
+        ret = gngraph_bizrules_rule_add_api(rjson, gndata_folder, gngraph_creds_folder)

--- a/gngraph/ingest/gngraph_ingest_main.py
+++ b/gngraph/ingest/gngraph_ingest_main.py
@@ -533,7 +533,7 @@ def      gngraph_init(rootDir):
     app_name = "gngraph"
     gngraph_cls = gnGraphIngest(rootDir)
 
-    console.log(' Gngraph Init no spark Context')
+    print(' Gngraph Init no spark Context')
     ### Set spark session
     ##spark = SparkSession.builder.appName(app_name).getOrCreate()
 

--- a/gngraph/ingest/gngraph_ingest_pd.py
+++ b/gngraph/ingest/gngraph_ingest_pd.py
@@ -1,4 +1,4 @@
-#Example python program to read data from a PostgreSQL table
+# Example python program to read data from a PostgreSQL table
 # and load into a pandas DataFrame
 
 import psycopg2
@@ -238,7 +238,7 @@ class     GNGraphIngestOps:
          self.__gngrp_cfg.save_edgeid_max(gn_edgeid_max_n)
 
          
-         
+
 def     gngraph_ingest_file_api(filename, ftype, fdelim, nodename, bizdomain, gndata_folder, gngraph_creds_folder):
 
 


### PR DESCRIPTION
GNGraph Implementation with postgres DB and Static files.

The new implementation will following directories 

gngraph/ : Main GNGraph related functions and classes

gngraph/ingest: 
   This directory contains  ingestion functions and classes. 

-     gngraph_ingest_pd.py: This file is Pandas-dataframe based ingestion to both PostgresDB and StaticFiles

gngraph/ingest/bizrules:  This directory contains functions and classes to add and search business rule driven logic. 
Currently the business rule format is JSON based  and the rule will applied to all graph nodes and appropriate  BizRule edges will be created.

gngraph/search: This directory contains search related functions and classes. 

- gngraph_search_main.py: This file  is Spark-based  functions to map existing nodes and then execute sql search to get nodes and edges. 
- gngraph_sqlparser.py: parses sql statement and used  to augment user-search queries.
-

gngraph/gngraph_dbops: 
This directory contains file and db operations for Postgres and Static files.  

The files: 
- gngraph_pgresdbops.py 
- gngraph_staticfileops.py 

 are used for ingestion and Pandas based. 

The files:
- gngraph_pgresdbops_srch.py
- gngraph_staticfiles_srch.py
are used for user search queries and spark-based


gndata/: The directory where gngraph data is stored as static files and also contains uploads directory.



